### PR TITLE
Add bewerbungs-automation project skeleton

### DIFF
--- a/bewerbungs-automation/.github/copilot-instructions.md
+++ b/bewerbungs-automation/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+Dieses Projekt automatisiert das Erstellen von Bewerbungsanschreiben mit einem LLM und dem docxtpl-Template-System.
+
+Verhalten von Copilot in diesem Repo:
+- Hilf beim Implementieren der LLM-Call-Logik in src/generate_content.py
+- Implementiere das Ausfüllen von docx-Templates in src/fill_template.py
+- Orchestriere Abläufe in src/main.py
+
+Nicht committen: .env (enthält API-Keys).

--- a/bewerbungs-automation/.gitignore
+++ b/bewerbungs-automation/.gitignore
@@ -1,0 +1,9 @@
+.env
+venv/
+output/
+__pycache__/
+*.pyc
+.vscode/
+*.log
+# optionally ignore generated docx if you don't want to commit them
+# output/*.docx

--- a/bewerbungs-automation/requirements.txt
+++ b/bewerbungs-automation/requirements.txt
@@ -1,0 +1,4 @@
+python-dotenv
+openai
+docxtpl
+python-docx

--- a/bewerbungs-automation/src/__init__.py
+++ b/bewerbungs-automation/src/__init__.py
@@ -1,0 +1,1 @@
+# src package for bewerbungs-automation

--- a/bewerbungs-automation/src/fill_template.py
+++ b/bewerbungs-automation/src/fill_template.py
@@ -1,0 +1,13 @@
+"""docxtpl helper to fill a .docx template with context data."""
+from docxtpl import DocxTemplate
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / 'templates'
+
+def fill_docx(template_name: str, context: dict, out_path: str) -> str:
+    """Fill template and save to out_path. Returns saved file path."""
+    tpl_path = TEMPLATES_DIR / template_name
+    doc = DocxTemplate(str(tpl_path))
+    doc.render(context)
+    doc.save(out_path)
+    return out_path

--- a/bewerbungs-automation/src/generate_content.py
+++ b/bewerbungs-automation/src/generate_content.py
@@ -1,0 +1,12 @@
+"""LLM call stubs for generating application text."""
+import os
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+
+def generate_cover_letter(context: dict) -> str:
+    """Return a generated cover letter text given context dict (name, position, company, skills...).
+    Replace this stub with the real API call (openai / your LLM client).
+    """
+    prompt = f"Create a concise German cover letter for {context.get('name')} applying to {context.get('position')} at {context.get('company')}. Include relevant skills: {context.get('skills')}."
+    # TODO: call OpenAI or other LLM here and return the text
+    return "[GENERATED COVER LETTER TEXT PLACEHOLDER]"

--- a/bewerbungs-automation/src/main.py
+++ b/bewerbungs-automation/src/main.py
@@ -1,0 +1,28 @@
+"""Orchestrator: load config, generate content, fill template, write output."""
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+from src.generate_content import generate_cover_letter
+from src.fill_template import fill_docx
+
+ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_DIR = ROOT / 'output'
+
+load_dotenv(ROOT / '.env')
+
+def run_example():
+    context = {
+        'name': 'Max Mustermann',
+        'position': 'Softwareentwickler',
+        'company': 'Beispiel GmbH',
+        'skills': 'Python, APIs, Testing'
+    }
+    text = generate_cover_letter(context)
+    # The template should contain a placeholder like {{ cover_text }} or map fields individually
+    tpl_context = {**context, 'cover_text': text}
+    out_file = OUTPUT_DIR / f"anschreiben_{context['name'].replace(' ', '_')}.docx"
+    fill_docx('anschreiben_template.docx', tpl_context, str(out_file))
+    print(f"Wrote: {out_file}")
+
+if __name__ == '__main__':
+    run_example()

--- a/bewerbungs-automation/templates/anschreiben_template.docx
+++ b/bewerbungs-automation/templates/anschreiben_template.docx
@@ -1,0 +1,3 @@
+PLACEHOLDER: Dies ist ein Platzhalter für dein Original-DOCX-Template mit Platzhaltern wie {{ name }}, {{ position }}, {{ company }}.
+
+Bitte ersetze diese Datei durch dein echtes .docx-Template mit Platzhaltern vor dem Ausführen.


### PR DESCRIPTION
Fügt die Grundstruktur und Stub-Dateien für das Projekt `bewerbungs-automation` hinzu:

- .github/copilot-instructions.md
- bewerbungs-automation/requirements.txt
- bewerbungs-automation/.gitignore
- bewerbungs-automation/.env (Platzhalter)
- bewerbungs-automation/templates/anschreiben_template.docx (Platzhalter)
- bewerbungs-automation/src/* (Stubs für generate, fill, main)

Enthält Platzhalter für das DOCX-Template und Hinweise zum Eintragen von API-Keys.